### PR TITLE
docs: add article on integrating Claude Code notifications with Slack

### DIFF
--- a/articles/claude-code-notifications-hook-to-slack.md
+++ b/articles/claude-code-notifications-hook-to-slack.md
@@ -1,0 +1,34 @@
+---
+title: "Claude Code の notifications hook で作業内容を良い感じに slack に送信する"
+emoji: "🚀"
+type: "tech" # tech: 技術記事 / idea: アイデア
+topics: ["slack", "claude code"]
+published: true
+---
+1. 以下を参考に incoming webhooks の設定をして webhook の URL をコピーする
+https://api.slack.com/messaging/webhooks
+
+2. ~/.claude/settings.json に以下の設定をする
+
+
+
+```json
+{
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "transcript_path=$(jq -r '.transcript_path') && jq -s '.[-3:]' \"$transcript_path\" | claude -p 'この会話の内容を日本語で簡潔に要約してください' | jq -Rs '{\"text\": .}' | curl -X POST -H 'Content-type: application/json' -d @- https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXXXX"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- `CLAUDE_CONFIG_DIR` を設定している方はファイルパスを読み替えてください
+- *webhook の URL は実際のものに置き換えてください*

--- a/articles/claude-code-notifications-hook-to-slack.md
+++ b/articles/claude-code-notifications-hook-to-slack.md
@@ -5,6 +5,10 @@ type: "tech" # tech: 技術記事 / idea: アイデア
 topics: ["slack", "claude code"]
 published: true
 ---
+python とか node を使わず shell のワンライナーで送信する方法です。
+`jq` や `curl` は使えるようにしておいてください。
+
+
 1. 以下を参考に incoming webhooks の設定をして webhook の URL をコピーする
 https://api.slack.com/messaging/webhooks
 


### PR DESCRIPTION
This pull request adds a new technical article about using the notifications hook in Claude Code to send summarized work updates to Slack. The article includes instructions for setting up Slack incoming webhooks and configuring Claude settings.

### New Article Addition:

* [`articles/claude-code-notifications-hook-to-slack.md`](diffhunk://#diff-dc7879a738f5a0b52e5db517ab243baad089b30214cebb1814ae7cc1061633dbR1-R34): Added a technical article titled "Claude Code の notifications hook で作業内容を良い感じに slack に送信する," which provides step-by-step instructions for integrating Claude Code with Slack using incoming webhooks and JSON configuration.