### PR TITLE
fix: Monolog 記事のタイトル超過とコードフェンス欠落を修正

### DIFF
--- a/articles/monolog-rotatingfilehandler-php-fpm-rotation.md
+++ b/articles/monolog-rotatingfilehandler-php-fpm-rotation.md
@@ -1,5 +1,5 @@
 ---
-title: "Monolog 1.x の RotatingFileHandler が php-fpm 下で古いログを消さない話（2.x / 3.x との挙動差）"
+title: "Monolog 1.x が php-fpm 下で古いログを消さない問題（2.x/3.x との挙動差）"
 emoji: "🗑️"
 type: "tech" # tech: 技術記事 / idea: アイデア
 topics: ["monolog", "php", "symfony", "eccube", "logging"]
@@ -285,6 +285,7 @@ ls -1t var/log/prod/site-*.log | tail -n +61 | xargs -r rm -f
 
 # 恒久：cron（Web 実行ユーザーの crontab）で 60 日分（当日含む）を残して古いログを削除
 5 0 * * * find /path/to/var/log/prod -name 'site-*.log' -mtime +59 -delete
+```
 
 `find -mtime` は Monolog のバージョン・`__destruct`・`glob`・`fingers_crossed` のいずれにも依存しないため、確実に効きます。
 


### PR DESCRIPTION
## 概要

マージ済み記事 `monolog-rotatingfilehandler-php-fpm-rotation.md` の Zenn デプロイが失敗していたため修正します。

## 修正内容

1. **タイトルが70文字超でデプロイエラー**（「Titleには最大70文字まで」）
   → 50文字に短縮:
   `Monolog 1.x が php-fpm 下で古いログを消さない問題（2.x/3.x との挙動差）`

2. **bash コードブロックの閉じ ` ``` ` 欠落を補完**
   - 直前の編集（#55 内 `2a72f07`）で対策セクションの cron コードブロックの閉じフェンスが消えていたため復元。
   - cron コマンドの変更内容（`-mtime +59` / `site-*.log`）はそのまま維持。

コードフェンスは偶数（20行）で閉じ整合を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)